### PR TITLE
Fixes to build against Linux 5.x kernel

### DIFF
--- a/home.c
+++ b/home.c
@@ -32,7 +32,7 @@ static void vms_ctime(vms_quad bintim, char *buf)
 	struct timespec64 ts;
 	struct tm tm;
 	ts = v2utime(bintim);
-	time_to_tm(ts.tv_sec, 0, &tm);
+	time64_to_tm(ts.tv_sec, 0, &tm);
 	sprintf(buf, "%02d-", tm.tm_mday);
 	sprintf(buf + 3, "%.3s-", &"JanFebMarAprMayJunJulAugSepOctNovDec"[tm.tm_mon * 3]);
 	sprintf(buf + 3 + 4, "%4ld ", tm.tm_year + 1900);

--- a/super.c
+++ b/super.c
@@ -660,7 +660,7 @@ static int ods5_fill_super(struct super_block *sb, void *data, int silent)
 	ods5_debug(2, "%s\n", "start");
 	ods5_info("options: '%s'\n", data? (char *)data: "<NULL>");
 
-	if ((sb->s_flags & MS_RDONLY) == 0) {
+	if ((sb->s_flags & SB_RDONLY) == 0) {
 		ods5_info("version %s only supports read-only\n", ODS5_MODVER);
 		return -EACCES;
 	}


### PR DESCRIPTION
The ODS-5 driver won't build on Linux Mint 'uma', based on Ubuntu 20.04, which uses the 5.4.0-104-generic kernel.

The minor changes in this PR allow the ODS/5 driver to build on newer kernels.